### PR TITLE
Comparing to `null` and `undefined`

### DIFF
--- a/api/controllers/bDateController.js
+++ b/api/controllers/bDateController.js
@@ -2,7 +2,7 @@
 var BadiCal = require('../../vendor/assets/badi-cal/index.js');
 
 function sanitize_input(s) {
-  if (s==''||s==undefined||s==null||s==false||isNaN(s)) { return 0; }
+  if (s==''||s===undefined||s===null||s==false||isNaN(s)) { return 0; }
   else { return parseInt(s,10); }
 }
 


### PR DESCRIPTION
- Avoid LGTM error by using identity operator to compare with `undefined`/`null`

As per MDN:

> "Null and Undefined Types are strictly equal to themselves and abstractly equal to each other."

Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators

So the check as is is redundant whereas the PR makes it non-redundant (and more precise as to intent).