### PR TITLE
Fix Gregorian date

### DIFF
--- a/api/controllers/bDateController.js
+++ b/api/controllers/bDateController.js
@@ -58,7 +58,7 @@ function getTodayJSON () {
     greg_date: {
       year: now.getFullYear(),
       month: now.getMonth() + 1,
-      day: now.getDay(),
+      day: now.getDate(),
       hour: now.getHours(),
       minute: now.getMinutes(),
       second: now.getSeconds()


### PR DESCRIPTION
- Fix: JavaScript `Date` `getDay` is for day of week; should be `getDate`.

The probable source of confusion is that in the `badi-cal` API, `getDay` returns the date, but with the JavaScript `Date` API, that returns the day of the week which isn't desirable here.