### PR TITLE
Timezones and latitude/longitude

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: No test specified\" && exit 1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Breaking change: Require Node 12
- Breaking change: Default to Bahjí for latitude, longitude, and timezoneId
- Enhancement: Allow latitude, longitude, timezoneId params (Closes #14 ) and show `timezoneId` in JSON
- Enhancement: Add `timezoneOffset` to Gregorian date (the timezoneId does not set this but the user should know what the local one we are generating is)