### PR TITLE
Create server

### DIFF
--- a/createServer.js
+++ b/createServer.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const express = require('express'),
+  bodyParser = require('body-parser'),
+  RateLimit = require('express-rate-limit');
+
+const routes = require('./api/routes/bDateRoutes.js'); // importing routes
+
+/**
+* @returns {ExpressApp}
+*/
+function createServer () {
+  const app = express();
+
+  app.use(new RateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 20
+  }));
+
+  app.use(bodyParser.urlencoded({extended: true}));
+  app.use(bodyParser.json());
+
+  routes(app); // register the routes
+
+  return app;
+}
+
+module.exports = createServer;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "echo \"Error: No test specified\" && exit 1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -1,23 +1,10 @@
 'use strict';
 
-const express = require('express'),
-  bodyParser = require('body-parser'),
-  RateLimit = require('express-rate-limit');
+const createServer = require('./createServer.js');
 
-const routes = require('./api/routes/bDateRoutes.js'); // importing route
+const port = process.argv[2] || 1844;
 
-const app = express(),
-  port = process.argv[2] || 1844;
-
-app.use(new RateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 20
-}));
-
-app.use(bodyParser.urlencoded({extended: true}));
-app.use(bodyParser.json());
-
-routes(app); // register the route
+const app = createServer();
 
 app.listen(port);
 


### PR DESCRIPTION
Builds on #23

- Enhancement: Split off server creation into own file so can use this script additively

This may end up helping with #15 since I should be able to modify textbrowser (as bahai-browser.org is using) fairly readily to accept a module string (such as pointing to this `createServer`) which when required will have its routes added to textbrowser's, allowing the date API to be hosted there. 
