### PR TITLE
chore: ignore lock file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml


### PR DESCRIPTION
Don't need one file in the pushed npm package.