### PR TITLE
fix: supply `command-line-basics` with notifier info

### DIFF
--- a/bin/bahai-date-api.js
+++ b/bin/bahai-date-api.js
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 
-import {dirname, join} from 'path';
-import {fileURLToPath} from 'url';
 import {cliBasics} from 'command-line-basics';
 import {
   getDate, getTodayJSON
 } from '../api/controllers/bDateController.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
 const optionDefinitions = await cliBasics(
-  join(__dirname, './optionDefinitions.js')
+  import.meta.dirname + '/optionDefinitions.js',
+  {
+    packageJsonPath: import.meta.dirname + '/../package.json'
+  }
 );
 
 if (!optionDefinitions) { // cliBasics handled

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "echo \"Error: No test specified\" && exit 1"
   },
   "engines": {
-    "node": ">=14.8.0"
+    "node": "^20.11.0 || >=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When using the command line, this fixes some behavior with checking that the user is using the latest version of the app. Also requires higher version of Node given the use of a JS feature.